### PR TITLE
Fix spelling of GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # haskell-exam-autograding
-Template repository for Haskell exams and projects. Includes devcontainer and GitHub Autograding action. Repository is intended for use with GiHub Classroom.
+Template repository for Haskell exams and projects. Includes devcontainer and GitHub Autograding action. Repository is intended for use with GitHub Classroom.


### PR DESCRIPTION
GiHub -> GitHub